### PR TITLE
change trib site links to http so they will load

### DIFF
--- a/source/_desktop_nav.erb
+++ b/source/_desktop_nav.erb
@@ -3,8 +3,8 @@
     <li <% if current_page.data.title == 'Become a Member' %>class="active"<% end %>><%= link_to 'Become<br> a Member<i class="fa fa-caret-down"></i>', '/index.html' %></li>
     <li <% if current_page.data.title == 'Explore Benefits' %>class="active"<% end %>><%= link_to 'Explore<br> Benefits<i class="fa fa-caret-down"></i>', '/levels.html' %></li>
     <li <% if current_page.data.title == 'Circle Membership' %>class="active"<% end %>><%= link_to 'Circle<br> Membership<i class="fa fa-caret-down"></i>', '/circle.html' %></li>
-    <li><a href="https://www.texastribune.org/support-us/donors-and-members/">Donor and<br> Member Wall</a></li>
-    <li><a href="https://www.texastribune.org/support-us/corporate-sponsors/">Corporate<br> Sponsors</a></li>
-    <li><a href="https://www.texastribune.org/support-us/frequently-asked-questions/">Frequently<br> Asked Questions</a></li>
+    <li><a href="http://www.texastribune.org/support-us/donors-and-members/">Donor and<br> Member Wall</a></li>
+    <li><a href="http://www.texastribune.org/support-us/corporate-sponsors/">Corporate<br> Sponsors</a></li>
+    <li><a href="http://www.texastribune.org/support-us/frequently-asked-questions/">Frequently<br> Asked Questions</a></li>
   </ul>
 </nav>

--- a/source/_mobile_nav.erb
+++ b/source/_mobile_nav.erb
@@ -3,8 +3,8 @@
     <li><%= link_to 'Become a Member', '/index.html' %></li>
     <li><%= link_to 'Explore Benefits', '/levels.html' %></li>
     <li><%= link_to 'Circle Membership', '/circle.html' %></li>
-    <li><a href="https://www.texastribune.org/support-us/donors-and-members/">Donor and Member Wall</a></li>
-    <li><a href="https://www.texastribune.org/support-us/corporate-sponsors/">Corporate Sponsors</a></li>
-    <li><a href="https://www.texastribune.org/support-us/frequently-asked-questions/">Frequently Asked Questions</a></li>
+    <li><a href="http://www.texastribune.org/support-us/donors-and-members/">Donor and Member Wall</a></li>
+    <li><a href="http://www.texastribune.org/support-us/corporate-sponsors/">Corporate Sponsors</a></li>
+    <li><a href="http://www.texastribune.org/support-us/frequently-asked-questions/">Frequently Asked Questions</a></li>
   </ul>
 </nav>


### PR DESCRIPTION
#### What's this PR do?

Changes the TT links to http so they load right.
#### Why are we doing this? How does it help us?

Unfortunately it's the standard for the current TT site; https doesn't load correctly for many things.
#### How should this be manually tested?

Check the Donor and Member link in mobile and desktop and make sure it loads.
#### What are the relevant tickets?

Off-sprint, Evan tried to load the donor wall and was sad.
#### Next steps?

n/a
#### Smells?

http not great but necessary for now :/
#### Has the relevant documentation/wiki been updated?

n/a
#### Technical debt note

slight increase
You can find a bookmarklet at: https://wiki.texastribune.org/display/TECH/GitHub
