### PR TITLE
Add in Mailchimp tracking for FMD

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -47,6 +47,15 @@
       window._fbq.push(['track', '6025650813658', {'value':'0.00','currency':'USD'}]);
     </script>
     <noscript><img height="1" width="1" alt="" style="display:none" src="https://www.facebook.com/tr?ev=6025650813658&amp;cd[value]=0.00&amp;cd[currency]=USD&amp;noscript=1" /></noscript>
+    <!-- Mailchimp tracking for FMD -->
+    <script type="text/javascript">
+      var $mcGoal = {'settings':{'uuid':'3d0ce87edeeb6df90043897db','dc':'us3'}};
+      (function() {
+           var sp = document.createElement('script'); sp.type = 'text/javascript'; sp.async = true; sp.defer = true;
+          sp.src = ('https:' == document.location.protocol ? 'https://s3.amazonaws.com/downloads.mailchimp.com' : 'http://downloads.mailchimp.com') + '/js/goal.min.js';
+          var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(sp, s);
+      })();
+  </script>
   </head>
   <body class="<%= page_classes %> no-js">
     <%= partial "header" %>


### PR DESCRIPTION
#### What's this PR do?

Adds in script to track Mailchimp campaign to head of layout template.
#### Why are we doing this? How does it help us?

Helps us track Mailchimp campaigns through FMD.
#### How should this be manually tested?

Run the project locally. Check that your AWS env variables and GOOGLE_DRIVE_KEY are set. Then
`bundle exec middleman`
Inspect the page and check the bottom of the head on any page for the Mailchimp tracking script.
#### Are there performance implications? If adding JS can it be done async? Do images/CSS/JS have cache headers set?

The added JS script is set to async. It will also be removed post-drive.
#### What are the relevant tickets?

Off-sprint email request.
#### Next steps?

Removes the tracking script after the FMD.
#### Smells?
#### TODOs:
#### Has the relevant documentation/wiki been updated?
#### Technical debt note

Same
