### PR TITLE
Streamline one-time donation process & update join/renew buttons

### DIFF
--- a/source/_bottom_checkout.erb
+++ b/source/_bottom_checkout.erb
@@ -15,9 +15,7 @@
           </div>
         </div>
         <button type="submit" class="button button-flat">Join or Renew <i class="fa fa-chevron-right"></i></button>
-        <a href="https://givalike.org/public/quickgive.aspx?cid=321" class="donate-link">
-          <p>Make a <span>One-Time Donation</span></p>
-        </a>
+        <div class="donate-link"><p>Make a <a href="https://givalike.org/public/quickgive.aspx?cid=321"><span>One-Time Donation</span></a></p></div>
       </form>
     </div>
   </div><!-- express-checkout -->

--- a/source/_bottom_checkout.erb
+++ b/source/_bottom_checkout.erb
@@ -14,10 +14,9 @@
               <label for="monthly-bottom"><i class="fa fa-check"></i>Monthly</label>
           </div>
         </div>
-        <button type="submit" class="button button-flat">Join Now <i class="fa fa-chevron-right"></i></button>
-        <a href="https://givalike.org/public/quickgive.aspx?cid=227">
-          <div class="button button-flat">Renew Today <i class="fa fa-chevron-right"></i>
-          </div>
+        <button type="submit" class="button button-flat">Join or Renew <i class="fa fa-chevron-right"></i></button>
+        <a href="https://givalike.org/public/quickgive.aspx?cid=321" class="donate-link">
+          <p>Make a <span>One-Time Donation</span></p>
         </a>
       </form>
     </div>

--- a/source/_top_checkout.erb
+++ b/source/_top_checkout.erb
@@ -13,11 +13,10 @@
         <h3 id="level-display">Activist</h3>
         <a href="/levels.html"><p class="italic"><strong><em>Explore benefits &amp; membership levels <i class="fa fa-chevron-right"></i></em></strong></p></a>
       </div>
-      <button type="submit" class="button button-flat">Join Now <i class="fa fa-chevron-right"></i></button>
+      <button type="submit" class="button button-flat">Join or Renew <i class="fa fa-chevron-right"></i></button>
     </form>
   </div>
   <div class="renew-donate">
-    <a href="https://givalike.org/public/quickgive.aspx?cid=227"><button class="button button-flat">Renew <i class="fa fa-chevron-right"></i></button></a>
-    <a href="https://givalike.org/Public/QuickGive.aspx?cid=321"><button class="button button-flat button-right">Donate <i class="fa fa-chevron-right"></i></button></a>
+    <a href="https://givalike.org/Public/QuickGive.aspx?cid=321"><button class="button button-flat">One-Time Donation <i class="fa fa-chevron-right"></i></button></a>
   </div>
 </div><!-- express-checkout -->

--- a/source/stylesheets/_checkout.scss
+++ b/source/stylesheets/_checkout.scss
@@ -177,12 +177,16 @@ input[type=number]::-webkit-outer-spin-button {
     }
     .contribute {
       background: transparent;
-      .donate-link p {
-        color: white;
-        font-size: 1.5em;
-        margin-top: 2em;
-        span {
-          text-decoration: underline;
+      .donate-link {
+        display: block;
+        p {
+          color: white;
+          font-size: 1.2em;
+          margin-top: 1em;
+          span {
+            color: white;
+            text-decoration: underline;
+          }
         }
       }
       .left-wrapper {

--- a/source/stylesheets/_checkout.scss
+++ b/source/stylesheets/_checkout.scss
@@ -62,10 +62,7 @@ input[type=number]::-webkit-outer-spin-button {
     .button {
       margin: 1em 0;
       padding: 0.5em 1.5em;
-      width: 48%;
-    }
-    .button-right {
-      float: right;
+      width: 100%;
     }
   }
   label {
@@ -180,6 +177,14 @@ input[type=number]::-webkit-outer-spin-button {
     }
     .contribute {
       background: transparent;
+      .donate-link p {
+        color: white;
+        font-size: 1.5em;
+        margin-top: 2em;
+        span {
+          text-decoration: underline;
+        }
+      }
       .left-wrapper {
         float: left;
         width: 75%;

--- a/source/stylesheets/_checkout.scss
+++ b/source/stylesheets/_checkout.scss
@@ -180,11 +180,11 @@ input[type=number]::-webkit-outer-spin-button {
       .donate-link {
         display: block;
         p {
-          color: white;
+          color: $white;
           font-size: 1.2em;
           margin-top: 1em;
           span {
-            color: white;
+            color: $white;
             text-decoration: underline;
           }
         }


### PR DESCRIPTION
#### What's this PR do?

It updates the checkout buttons so that there's no longer a separate "Renew" button, but a joint "Join or Renew" button. The "Donate" button has been enlarged at the top and updated to read "One-Time Donation." For the bottom checkout, there's now a "One-Time Donation" link in place of a separate "Renew" button.
#### Why are we doing this? How does it help us?

Helps us by increasing the visibility of the "One-Time Donation" option, which some people have asked about. Also streamlines the "Join" and "Renew" processes.
#### How should this be manually tested?

Visit the app locally.
Go to the landing page first. See that the top checkout "Join or Renew" button and "One-Time Donation" button take you where expected. See that the bottom checkout button and link also take you where expected. Check on tablet and mobile sizes, as well. Also look at the bottom checkout on the "Explore Membership Benefits" page.
#### Are there performance implications? If adding JS can it be done async? Do images/CSS/JS have cache headers set?

Shouldn't be.
#### What are the relevant tickets?

Part of Sprint task.
#### Next steps?
#### Smells?

Don't think so.
#### TODOs:
- [x] Discuss the updates with art & get Ben's approval
- [x] Discuss updates to get Allison's approval
#### Has the relevant documentation/wiki been updated?
#### Technical debt note

Same
