### PR TITLE
Update from monthly to quarterly

### DIFF
--- a/data/levels.yml
+++ b/data/levels.yml
@@ -5,7 +5,7 @@
   student: true
   all_content_benefits:
     -
-      "Monthly membership report from CEO and Editor-in-Chief Evan Smith"
+      "Quarterly membership report from CEO and Editor-in-Chief Evan Smith"
   all_recognition_benefits:
     -
       "Your name as a Tribune member on our website"
@@ -18,7 +18,7 @@
   all_above: false
   all_content_benefits:
     -
-      "Monthly membership report from CEO and Editor-in-Chief Evan Smith"
+      "Quarterly membership report from CEO and Editor-in-Chief Evan Smith"
   all_access_benefits:
     -
       "Invitations to Tribune social events"
@@ -38,7 +38,7 @@
   all_above: true
   all_content_benefits:
     -
-      "Monthly membership report from CEO and Editor-in-Chief Evan Smith"
+      "Quarterly membership report from CEO and Editor-in-Chief Evan Smith"
   all_access_benefits:
     -
       "Invitations to Tribune social events"
@@ -59,7 +59,7 @@
   all_above: true
   all_content_benefits:
     -
-      "Monthly membership report from CEO and Editor-in-Chief Evan Smith"
+      "Quarterly membership report from CEO and Editor-in-Chief Evan Smith"
     -
       "Promotions such as discounts to Texas Weekly (which includes 12 months of The Washington Post Digital edition)"
   all_access_benefits:
@@ -91,7 +91,7 @@
   all_above: true
   all_content_benefits:
     -
-      "Monthly membership report from CEO and Editor-in-Chief Evan Smith"
+      "Quarterly membership report from CEO and Editor-in-Chief Evan Smith"
     -
       "Promotions such as discounts to Texas Weekly (which includes 12 months of The Washington Post Digital edition)"
     -
@@ -120,7 +120,7 @@
   all_above: true
   all_content_benefits:
     -
-      "Monthly membership report from CEO and Editor-in-Chief Evan Smith"
+      "Quarterly membership report from CEO and Editor-in-Chief Evan Smith"
     -
       "Promotions such as discounts to Texas Weekly (which includes 12 months of The Washington Post Digital edition)"
     -
@@ -157,7 +157,7 @@
   circle: true
   all_content_benefits:
     -
-      "Monthly membership report from CEO and Editor-in-Chief Evan Smith"
+      "Quarterly membership report from CEO and Editor-in-Chief Evan Smith"
     -
       "Promotions such as discounts to Texas Weekly (which includes 12 months of The Washington Post Digital edition)"
     -
@@ -193,7 +193,7 @@
   circle: true
   all_content_benefits:
     -
-      "Monthly membership report from CEO and Editor-in-Chief Evan Smith"
+      "Quarterly membership report from CEO and Editor-in-Chief Evan Smith"
     -
       "Promotions such as discounts to Texas Weekly (which includes 12 months of The Washington Post Digital edition)"
     -
@@ -231,7 +231,7 @@
   circle: true
   all_content_benefits:
     -
-      "Monthly membership report from CEO and Editor-in-Chief Evan Smith"
+      "Quarterly membership report from CEO and Editor-in-Chief Evan Smith"
     -
       "Promotions such as discounts to Texas Weekly (which includes 12 months of The Washington Post Digital edition)"
     -

--- a/source/_footer.erb
+++ b/source/_footer.erb
@@ -1,4 +1,4 @@
-<footer class="footer">
+<footer id="footer" class="footer">
   <nav class="left-nav">
     <ul>
       <li class="copyright">&copy; 2015 <a href="http://www.texastribune.org/">The Texas Tribune</a></li>


### PR DESCRIPTION
#### What's this PR do?

Updates monthly membership report to quarterly membership report
#### Why are we doing this? How does it help us?

Makes the site more accurately reflect what membership levels receive.
#### How should this be manually tested?

Visit the /levels.html page locally. See that under each level, it states 'quarterly membership report' as a benefit, and not 'monthly membership report'. 

You can also check the contacts and FAQ page to see that they're pulling in the new info that Rodney entered in our Google doc.
#### Have automated tests been added?

no
#### Are there performance implications? If adding JS can it be done async? Do images/CSS/JS have cache headers set?

no
#### What are the relevant tickets?

Off-sprint requests
#### How should this change be communicated to end users?

Let Rodney and Suzanne know these updates are live.
#### Next steps?

It would be nice to make the level updates enterable in a Google doc, same as the FAQ, Contacts, and Info.
#### Smells?
#### TODOs:
#### Has the relevant documentation/wiki been updated?

I updated how to update the spreadsheet in our wiki.
#### Technical debt note

Same
