### PR TITLE
Sustain copy updates & click events

### DIFF
--- a/source/_bottom_checkout.erb
+++ b/source/_bottom_checkout.erb
@@ -15,7 +15,7 @@
           </div>
         </div>
         <button type="submit" class="button button-flat">Join or Renew <i class="fa fa-chevron-right"></i></button>
-        <div class="donate-link"><p>Make a <a href="https://checkout.texastribune.org/donateform"><span>One-Time Donation</span></a></p></div>
+        <div class="donate-link"><p>Make a <a href="https://checkout.texastribune.org/donateform" onclick="ga('send', 'event', 'donations-app', 'click', 'bottom-checkout-donation', {'nonInteraction': 1})"><span>One-Time Donation</span></a></p></div>
       </form>
     </div>
   </div><!-- express-checkout -->

--- a/source/_footer.erb
+++ b/source/_footer.erb
@@ -6,13 +6,13 @@
   </nav>
   <nav class="right-nav">
     <ul>
-      <li><a href="http://www.texastribune.org/about/">About Us</a></li>
-      <li><a href="http://www.texastribune.org/contact/">Contact Us</a></li>
-      <li><a href="http://www.texastribune.org/support-us/donors-and-members/">Who Funds Us?</a></li>
-      <li><a href="http://www.texastribune.org/terms-of-service/">Terms of Service</a></li>
-      <li><a href="http://www.texastribune.org/ethics/">Code of Ethics</a></li>
-      <li><a href="http://www.texastribune.org/privacy/">Privacy Policy</a></li>
-      <li class="donate"><a href="https://checkout.texastribune.org/donateform">Donate</a></li>
+      <li><a href="http://www.texastribune.org/about/" onclick="ga('send', 'event', 'donations-app', 'click', 'footer-about', {'nonInteraction': 1})">About Us</a></li>
+      <li><a href="http://www.texastribune.org/contact/" onclick="ga('send', 'event', 'donations-app', 'click', 'footer-contact', {'nonInteraction': 1})">Contact Us</a></li>
+      <li><a href="http://www.texastribune.org/support-us/donors-and-members/" onclick="ga('send', 'event', 'donations-app', 'click', 'footer-funds', {'nonInteraction': 1})">Who Funds Us?</a></li>
+      <li><a href="http://www.texastribune.org/terms-of-service/" onclick="ga('send', 'event', 'donations-app', 'click', 'footer-terms', {'nonInteraction': 1})">Terms of Service</a></li>
+      <li><a href="http://www.texastribune.org/ethics/" onclick="ga('send', 'event', 'donations-app', 'click', 'footer-ethics', {'nonInteraction': 1})">Code of Ethics</a></li>
+      <li><a href="http://www.texastribune.org/privacy/" onclick="ga('send', 'event', 'donations-app', 'click', 'footer-privacy', {'nonInteraction': 1})">Privacy Policy</a></li>
+      <li class="donate"><a href="https://checkout.texastribune.org/donateform" onclick="ga('send', 'event', 'donations-app', 'click', 'footer-donate', {'nonInteraction': 1})">Donate</a></li>
     </ul>
   </nav>
 </footer>

--- a/source/_mail_check.erb
+++ b/source/_mail_check.erb
@@ -1,4 +1,4 @@
 <div class="extra-info">
   <h3>Prefer to mail a check?</h3>
-  <p>Click <a href="https://static.texastribune.org/media/marketing/TT-membership-form-2016.pdf">here</a> for our membership form and mailing information. </p>
+  <p>Click <a href="https://static.texastribune.org/media/marketing/TT-membership-form-2016.pdf" onclick="ga('send', 'event', 'donations-app', 'click', 'mail-check', {'nonInteraction': 1})">here</a> for our membership form and mailing information. </p>
 </div>

--- a/source/_top_checkout.erb
+++ b/source/_top_checkout.erb
@@ -18,12 +18,12 @@
           <h5>Give $<span id="give-more">4</span> More:</h5>
           <h3 id="level-next">Advocate</h3>
         </div>
-        <a href="/levels.html"><p class="italic"><strong><em>Explore all membership levels <i class="fa fa-chevron-right"></i></em></strong></p></a>
+        <a href="/levels.html" onclick="ga('send', 'event', 'donations-app', 'click', 'explore-levels-top-checkout', {'nonInteraction': 1})"><p class="italic"><strong><em>Explore all membership levels <i class="fa fa-chevron-right"></i></em></strong></p></a>
       </div>
       <button type="submit" class="button button-flat">Join or Renew <i class="fa fa-chevron-right"></i></button>
     </form>
   </div>
   <div class="renew-donate">
-    <a href="https://checkout.texastribune.org/donateform"><button class="button button-flat">One-Time Donation <i class="fa fa-chevron-right"></i></button></a>
+    <a href="https://checkout.texastribune.org/donateform" onclick="ga('send', 'event', 'donations-app', 'click', 'donation-top-checkout', {'nonInteraction': 1})"><button class="button button-flat">One-Time Donation <i class="fa fa-chevron-right"></i></button></a>
   </div>
 </div><!-- express-checkout -->

--- a/source/_videos.erb
+++ b/source/_videos.erb
@@ -1,6 +1,6 @@
 <div class="video-label">Our mission in action</div>
 <div class="outer-info video-wrapper" id="video-top">
-  <a class="video inner-info" href="https://www.youtube.com/watch?v=m4RbuLrJV48">Watch Now</a>
+  <a class="video inner-info" href="https://www.youtube.com/watch?v=Sqv-lctyLBc">Watch Now</a>
 </div>
 <div class="watch-more">
   <a href="https://www.texastribune.org/multimedia/video/" onclick="ga('send', 'event', 'donations-app', 'click', 'watch-top-video', {'nonInteraction': 1})">Watch more videos <i class="fa fa-chevron-right"></i></a>
@@ -9,7 +9,7 @@
 <div class="outer-video-wrapper">
   <div class="video-label">60+ free, statewide events a year</div>
   <div class="outer-info video-wrapper secondary-video" id="video-two">
-    <a class="video inner-info" href="https://www.youtube.com/watch?v=sUVdFd6Ug5I" onclick="ga('send', 'event', 'donations-app', 'click', 'watch-video-2', {'nonInteraction': 1})">Watch Now</a>
+    <a class="video inner-info" href="https://www.youtube.com/watch?v=h1W6UzIZZ7c" onclick="ga('send', 'event', 'donations-app', 'click', 'watch-video-2', {'nonInteraction': 1})">Watch Now</a>
   </div>
   <div class="video-label">Hard-hitting investigative projects</div>
   <div class="outer-info video-wrapper secondary-video" id="video-three">

--- a/source/_videos.erb
+++ b/source/_videos.erb
@@ -3,20 +3,20 @@
   <a class="video inner-info" href="https://www.youtube.com/watch?v=m4RbuLrJV48">Watch Now</a>
 </div>
 <div class="watch-more">
-  <a href="https://www.texastribune.org/multimedia/video/">Watch more videos <i class="fa fa-chevron-right"></i></a>
+  <a href="https://www.texastribune.org/multimedia/video/" onclick="ga('send', 'event', 'donations-app', 'click', 'watch-top-video', {'nonInteraction': 1})">Watch more videos <i class="fa fa-chevron-right"></i></a>
   <hr>
 </div>
 <div class="outer-video-wrapper">
   <div class="video-label">60+ free, statewide events a year</div>
   <div class="outer-info video-wrapper secondary-video" id="video-two">
-    <a class="video inner-info" href="https://www.youtube.com/watch?v=sUVdFd6Ug5I">Watch Now</a>
+    <a class="video inner-info" href="https://www.youtube.com/watch?v=sUVdFd6Ug5I" onclick="ga('send', 'event', 'donations-app', 'click', 'watch-video-2', {'nonInteraction': 1})">Watch Now</a>
   </div>
   <div class="video-label">Hard-hitting investigative projects</div>
   <div class="outer-info video-wrapper secondary-video" id="video-three">
-    <a class="video inner-info" href="https://www.youtube.com/watch?v=GM-jnuGjFjA">Watch Now</a>
+    <a class="video inner-info" href="https://www.youtube.com/watch?v=GM-jnuGjFjA" onclick="ga('send', 'event', 'donations-app', 'click', 'watch-video-3', {'nonInteraction': 1})">Watch Now</a>
   </div>
   <div class="video-label">Interactive data projects</div>
   <div class="outer-info video-wrapper secondary-video" id="video-four">
-    <a class="video inner-info" href="https://www.youtube.com/watch?v=jMMWVNzxiPs">Watch Now</a>
+    <a class="video inner-info" href="https://www.youtube.com/watch?v=jMMWVNzxiPs" onclick="ga('send', 'event', 'donations-app', 'click', 'watch-video-4', {'nonInteraction': 1})">Watch Now</a>
   </div>
 </div>

--- a/source/circle.html.erb
+++ b/source/circle.html.erb
@@ -17,8 +17,8 @@ title: Circle Membership
             <p><em>Three-Year Commitment</em></p>
           </div>
           <div class="circle-box-bottom">
-            <a href="https://checkout.texastribune.org/circleform?&amp;amount=<%= level.amount_annual %>&amp;installmentPeriod=yearly&amp;installments=3"><button class="button button-flat">$<%= level.amount_annual_comma %> <br>Annually</button></a>
-            <a href="https://checkout.texastribune.org/circleform?&amp;amount=<%= level.amount_month %>&amp;installmentPeriod=monthly&amp;installments=3"><button style="float: right;" class="button button-flat">$<%= level.amount_month %> <br>Monthly</button></a>
+            <a href="https://checkout.texastribune.org/circleform?&amp;amount=<%= level.amount_annual %>&amp;installmentPeriod=yearly&amp;installments=3" onclick="ga('send', 'event', 'donations-app', 'click', 'circle-yearly', {'nonInteraction': 1})"><button class="button button-flat">$<%= level.amount_annual_comma %> <br>Annually</button></a>
+            <a href="https://checkout.texastribune.org/circleform?&amp;amount=<%= level.amount_month %>&amp;installmentPeriod=monthly&amp;installments=3" onclick="ga('send', 'event', 'donations-app', 'click', 'circle-monthly', {'nonInteraction': 1})"><button style="float: right;" class="button button-flat">$<%= level.amount_month %> <br>Monthly</button></a>
           </div>
         </div>
       <% end %>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -34,7 +34,7 @@ title: Become a Member
   </div><!-- main-left -->
   <div class="main-right">
     <div class="student-member">
-      <a href="https://checkout.texastribune.org/memberform?&amp;amount=10&amp;installmentPeriod=yearly">Interested in becoming a student member? <i class="fa fa-chevron-right"></i></a>
+      <a href="https://checkout.texastribune.org/memberform?&amp;amount=10&amp;installmentPeriod=yearly" onclick="ga('send', 'event', 'donations-app', 'click', 'student-member', {'nonInteraction': 1})">Interested in becoming a student member? <i class="fa fa-chevron-right"></i></a>
     </div>
     <hr>
     <% data.levels.each do |level| %>
@@ -48,7 +48,7 @@ title: Become a Member
           <% end %>
           <h3><%= level.name %></h3>
           <h4 class="amount">
-            <% if level.amount_month %><a href="https://checkout.texastribune.org/<% if level.circle %>circle<% else %>member<% end %>form?&amp;amount=<%= level.amount_month %><% if level.circle %>&amp;installments=36<% end %>&amp;installmentPeriod=monthly">$<%= level.amount_month %> Monthly</a> <span>or</span> <% end %><a href="https://checkout.texastribune.org/<% if level.circle %>circle<% else %>member<% end %>form?&amp;amount=<%= level.amount_annual %>&amp;installmentPeriod=yearly<% if level.circle %>&amp;installments=3<% end %>"><% if level.amount_annual_comma %>$<%= level.amount_annual_comma %><% else %>$<%= level.amount_annual %><% end %> Annually</a></h4>
+            <% if level.amount_month %><a href="https://checkout.texastribune.org/<% if level.circle %>circle<% else %>member<% end %>form?&amp;amount=<%= level.amount_month %><% if level.circle %>&amp;installments=36<% end %>&amp;installmentPeriod=monthly" onclick="ga('send', 'event', 'donations-app', 'click', 'index-right-monthly-member', {'nonInteraction': 1})">$<%= level.amount_month %> Monthly</a> <span>or</span> <% end %><a href="https://checkout.texastribune.org/<% if level.circle %>circle<% else %>member<% end %>form?&amp;amount=<%= level.amount_annual %>&amp;installmentPeriod=yearly<% if level.circle %>&amp;installments=3<% end %>" onclick="ga('send', 'event', 'donations-app', 'click', 'index-right-yearly-member', {'nonInteraction': 1})"><% if level.amount_annual_comma %>$<%= level.amount_annual_comma %><% else %>$<%= level.amount_annual %><% end %> Annually</a></h4>
           <% if level.commitment %>
             <p class="italic">Three-Year Commitment</p>
           <% end %>

--- a/source/javascripts/main.js
+++ b/source/javascripts/main.js
@@ -158,6 +158,8 @@ $(document).ready(function() {
     // Don't submit the form as is
     e.preventDefault();
 
+    ga('send', 'event', 'donations-app', 'click', 'top-checkout-submit', {'nonInteraction': 1});
+
     var installmentPeriod, installments;
 
     // Base url for form
@@ -246,6 +248,8 @@ $(document).ready(function() {
 
     // Don't submit the form as is
     e.preventDefault();
+
+    ga('send', 'event', 'donations-app', 'click', 'bottom-checkout-submit', {'nonInteraction': 1});
 
     var installmentPeriod, installments;
 

--- a/source/levels.html.erb
+++ b/source/levels.html.erb
@@ -32,9 +32,9 @@ title: Explore Benefits
             <h5 class="benefit-flag"><i class="fa fa-star"></i> Most Popular</h5>
           <% end %>
         </td>
-        <% if level.amount_month %><td class="amount-monthly"><a href="https://checkout.texastribune.org/<% if level.circle %>circle<% else %>member<% end %>form?&amp;amount=<%= level.amount_month %><% if level.circle %>&amp;installments=36<% end %>&amp;installmentPeriod=monthly"><% if level.range_month %><%= level.range_month %><% else %>$<%= level.amount_month %><% end %> Monthly</a></td><% end %>
+        <% if level.amount_month %><td class="amount-monthly"><a href="https://checkout.texastribune.org/<% if level.circle %>circle<% else %>member<% end %>form?&amp;amount=<%= level.amount_month %><% if level.circle %>&amp;installments=36<% end %>&amp;installmentPeriod=monthly" onclick="ga('send', 'event', 'donations-app', 'click', 'levels-page-monthly-contrib', {'nonInteraction': 1})"><% if level.range_month %><%= level.range_month %><% else %>$<%= level.amount_month %><% end %> Monthly</a></td><% end %>
         <td class="amount-yearly">
-          <a href="https://checkout.texastribune.org/<% if level.circle %>circle<% else %>member<% end %>form?&amp;amount=<%= level.amount_annual %><% if level.circle %>&amp;installments=3<% end %>&amp;installmentPeriod=yearly"><% if level.range_annual %><%= level.range_annual %><% else %><% if level.amount_annual_comma %>$<%= level.amount_annual_comma %><% else %>$<%= level.amount_annual %><% end %><% end %> Annually</a>
+          <a href="https://checkout.texastribune.org/<% if level.circle %>circle<% else %>member<% end %>form?&amp;amount=<%= level.amount_annual %><% if level.circle %>&amp;installments=3<% end %>&amp;installmentPeriod=yearly" onclick="ga('send', 'event', 'donations-app', 'click', 'levels-page-annual-contrib', {'nonInteraction': 1})"><% if level.range_annual %><%= level.range_annual %><% else %><% if level.amount_annual_comma %>$<%= level.amount_annual_comma %><% else %>$<%= level.amount_annual %><% end %><% end %> Annually</a>
         </td>
       </tr>
       <tr class="popout">

--- a/source/levels.html.erb
+++ b/source/levels.html.erb
@@ -15,7 +15,8 @@ title: Explore Benefits
 
 <div class="main">
   <h2 class="tagline"><%= data.Info[0]['tagline'] %></h2>
-  <h3>Explore the benefits:</h3>
+  <h3>Explore the benefits</h3>
+  <p>Sustaining membership allows you to support journalism that matters with your ongoing monthly or yearly gift from your credit card.  It auto-renews each year, and helps eliminate renewal mailings or lapses in your membership.</p>
   <table>
     <% data.levels.each do |level| %>
     <tbody class="grid-body <% if level.most_popular %>opened<% end %>">


### PR DESCRIPTION
#### What's this PR do?
- Adds sustaining membership sentences to top of levels page
- Adds click events to links and buttons
#### Why are we doing this? How does it help us?
- The sustaining member copy is meant to help clarify that our membership levels are sustaining memberships
- The click events help us know which links and buttons folks are finding helpful to becoming members and donating
#### How should this be manually tested?
- Visit the levels page. See the new sentences beneath "Explore the benefits" at the top that discuss sustaining membership
- It's more difficult to test that the GA click events are being sent through as expected. Can click around the links in the top checkout, bottom checkout, right rail, video "WATCH NOW"s, levels page, circles page, and footer, just to be sure that they're working as expected and the click events aren't interfering with their expected behavior.
#### Have automated tests been added?

no
#### Are there performance implications? If adding JS can it be done async? Do images/CSS/JS have cache headers set?

no
#### What are the relevant tickets?

Part of SMD2016 updates, requested by Terry.
#### How should this change be communicated to end users?

In communication with Terry.
#### Next steps?

Analyze the click events to see what folks are finding most useful.
#### Smells?

Don't think so
#### TODOs:
#### Has the relevant documentation/wiki been updated?
#### Technical debt note

Same
