### PR TITLE
Measure more

### DIFF
--- a/source/_desktop_nav.erb
+++ b/source/_desktop_nav.erb
@@ -1,10 +1,22 @@
 <nav class="nav desktop-nav">
   <ul>
-    <li <% if current_page.data.title == 'Become a Member' %>class="active"<% end %>><%= link_to 'Become<br> a Member<i class="fa fa-caret-down"></i>', '/index.html' %></li>
-    <li <% if current_page.data.title == 'Explore Benefits' %>class="active"<% end %>><%= link_to 'Explore<br> Benefits<i class="fa fa-caret-down"></i>', '/levels.html' %></li>
-    <li <% if current_page.data.title == 'Circle Membership' %>class="active"<% end %>><%= link_to 'Circle<br> Membership<i class="fa fa-caret-down"></i>', '/circle.html' %></li>
-    <li><a href="http://www.texastribune.org/support-us/donors-and-members/">Donor and<br> Member Wall</a></li>
-    <li><a href="http://www.texastribune.org/support-us/corporate-sponsors/">Corporate<br> Sponsors</a></li>
-    <li <% if current_page.data.title == 'Frequently Asked Questions' %>class="active"<% end %>><%= link_to 'Frequently<br> Asked Questions<i class="fa fa-caret-down"></i>', '/faq.html' %></li>
+    <li <% if current_page.data.title == 'Become a Member' %>class="active"<% end %>>
+      <a href="/index.html" onclick="ga('send', 'event', 'donations-app', 'click', 'desktop-nav-become-member', {'nonInteraction': 1})">Become<br> a Member<i class="fa fa-caret-down"></i></a>
+    </li>
+    <li <% if current_page.data.title == 'Explore Benefits' %>class="active"<% end %>>
+      <a href="/levels.html" onclick="ga('send', 'event', 'donations-app', 'click', 'desktop-nav-explore-benefits', {'nonInteraction': 1})">Explore<br> Benefits<i class="fa fa-caret-down"></i></a>
+    </li>
+    <li <% if current_page.data.title == 'Circle Membership' %>class="active"<% end %>>
+      <a href="/circle.html" onclick="ga('send', 'event', 'donations-app', 'click', 'desktop-nav-circle-member', {'nonInteraction': 1})">Circle<br> Membership<i class="fa fa-caret-down"></i></a>
+    </li>
+    <li>
+      <a href="http://www.texastribune.org/support-us/donors-and-members/" onclick="ga('send', 'event', 'donations-app', 'click', 'desktop-nav-donor-member-wall', {'nonInteraction': 1})">Donor and<br> Member Wall</a>
+    </li>
+    <li>
+      <a href="http://www.texastribune.org/support-us/corporate-sponsors/" onclick="ga('send', 'event', 'donations-app', 'click', 'desktop-nav-corporate-sponsors', {'nonInteraction': 1})">Corporate<br> Sponsors</a>
+    </li>
+    <li <% if current_page.data.title == 'Frequently Asked Questions' %>class="active"<% end %>>
+      <a href="/faq.html" onclick="ga('send', 'event', 'donations-app', 'click', 'desktop-nav-faq', {'nonInteraction': 1})">Frequently<br> Asked Questions<i class="fa fa-caret-down"></i></a>
+    </li>
   </ul>
 </nav>

--- a/source/_mobile_nav.erb
+++ b/source/_mobile_nav.erb
@@ -1,10 +1,22 @@
 <nav class="nav mobile-nav">
   <ul>
-    <li><%= link_to 'Become a Member', '/index.html' %></li>
-    <li><%= link_to 'Explore Benefits', '/levels.html' %></li>
-    <li><%= link_to 'Circle Membership', '/circle.html' %></li>
-    <li><a href="http://www.texastribune.org/support-us/donors-and-members/">Donor and Member Wall</a></li>
-    <li><a href="http://www.texastribune.org/support-us/corporate-sponsors/">Corporate Sponsors</a></li>
-    <li><%= link_to 'Frequently Asked Questions', '/faq.html' %></li>
+    <li>
+      <a href="/index.html" onclick="ga('send', 'event', 'donations-app', 'click', 'mobile-nav-become-member', {'nonInteraction': 1})">Become a Member</a>
+    </li>
+    <li>
+      <a href="/levels.html" onclick="ga('send', 'event', 'donations-app', 'click', 'mobile-nav-explore-benefits', {'nonInteraction': 1})">Explore Benefits</a>
+    </li>
+    <li>
+      <a href="/circle.html" onclick="ga('send', 'event', 'donations-app', 'click', 'mobile-nav-circle-member', {'nonInteraction': 1})">Circle Membership</a>
+    </li>
+    <li>
+      <a href="https://www.texastribune.org/support-us/donors-and-members/" onclick="ga('send', 'event', 'donations-app', 'click', 'mobile-nav-donor-member-wall', {'nonInteraction': 1})">Donor and Member Wall</a>
+    </li>
+    <li>
+      <a href="https://www.texastribune.org/support-us/corporate-sponsors/" onclick="ga('send', 'event', 'donations-app', 'click', 'mobile-nav-corporate-sponsors', {'nonInteraction': 1})">Corporate Sponsors</a>
+    </li>
+    <li>
+      <a href="/faq.html" onclick="ga('send', 'event', 'donations-app', 'click', 'mobile-nav-faq', {'nonInteraction': 1})">Frequently Asked Questions</a>
+    </li>
   </ul>
 </nav>

--- a/source/javascripts/main.js
+++ b/source/javascripts/main.js
@@ -139,6 +139,7 @@ $(document).ready(function() {
     currentVal *= 12;
     newVal = currentVal;
     $('#spinner').attr('value', newVal);
+    ga('send', 'event', 'donations-app', 'click', 'top-checkout-annual-toggle', {'nonInteraction': 1});
     displayLevel();
   });
 
@@ -148,6 +149,7 @@ $(document).ready(function() {
     currentVal = parseInt($('#spinner').val());
     newVal = Math.ceil(currentVal / 12);
     $('#spinner').attr('value', newVal);
+    ga('send', 'event', 'donations-app', 'click', 'top-checkout-monthly-toggle', {'nonInteraction': 1});
     displayLevel();
   });
 
@@ -231,6 +233,7 @@ $(document).ready(function() {
     currentVal = parseInt($('#spinner-bottom').val());
     currentVal *= 12;
     newVal = currentVal;
+    ga('send', 'event', 'donations-app', 'click', 'bottom-checkout-annual-toggle', {'nonInteraction': 1});
     $('#spinner-bottom').attr('value', newVal);
   });
 
@@ -239,6 +242,7 @@ $(document).ready(function() {
     var currentVal, newVal;
     currentVal = parseInt($('#spinner-bottom').val());
     newVal = Math.ceil(currentVal / 12);
+    ga('send', 'event', 'donations-app', 'click', 'bottom-checkout-monthly-toggle', {'nonInteraction': 1});
     $('#spinner-bottom').attr('value', newVal);
   });
 

--- a/source/stylesheets/_checkout.scss
+++ b/source/stylesheets/_checkout.scss
@@ -279,6 +279,7 @@ input[type=number]::-webkit-outer-spin-button {
       }
       span.dollar {
         color: $white;
+        float: left;
         padding: 0 0.2em;
         width: 20%;
       }


### PR DESCRIPTION
#### What's this PR do?

Add GA click event trackers to our desktop and mobile nav links. In addition, also add them to the annual/monthly toggles. Small CSS update to bottom checkout dollar sign.
#### Why are we doing this? How does it help us?

We're already tracking almost all other clicks on our donations app; we want to track these too.
#### How should this be manually tested?

Can test out the GA click event trackers by making sure the links still work as expected. Otherwise, check that the click event information we're sending through matches the action. We can change in on the click events in GA in a day or two to make sure they're getting sent through as expected.
#### Have automated tests been added?

no
#### Are there performance implications? If adding JS can it be done async? Do images/CSS/JS have cache headers set?

no
#### What are the relevant tickets?

Part of https://3.basecamp.com/3098728/buckets/736178/todos/120094149
#### How should this change be communicated to end users?

Keep communicating our event info to the development/membership team.
#### Next steps?

Check in GA for the click event info we're getting.
#### Smells?
#### TODOs:
#### Has the relevant documentation/wiki been updated?
#### Technical debt note

Same
