### PR TITLE
Add membership form pdf to circle page

### DIFF
--- a/source/_mail_check.erb
+++ b/source/_mail_check.erb
@@ -1,4 +1,4 @@
 <div class="extra-info">
   <h3>Prefer to mail a check?</h3>
-  <p>Click <a href="https://static.texastribune.org/media/marketing/TT-membership-form-2016.pdf" onclick="ga('send', 'event', 'donations-app', 'click', 'mail-check', {'nonInteraction': 1})">here</a> for our membership form and mailing information. </p>
+  <p>Click <a href="https://static.texastribune.org/media/marketing/TT-membership-contribution-form.pdf" onclick="ga('send', 'event', 'donations-app', 'click', 'mail-check', {'nonInteraction': 1})">here</a> for our membership form and mailing information. </p>
 </div>

--- a/source/circle.html.erb
+++ b/source/circle.html.erb
@@ -61,6 +61,11 @@ title: Circle Membership
     <%= partial "give_more" %>
     <hr>
     <%= partial "share" %>
+    <hr>
+    <div class="extra-info">
+      <h3>Prefer to mail a check?</h3>
+      <p>Click <a href="https://static.texastribune.org/media/marketing/TT-circle-membership-contribution-form.pdf" onclick="ga('send', 'event', 'donations-app', 'click', 'mail-check', {'nonInteraction': 1})">here</a> for our membership form and mailing information. </p>
+    </div>
   </div>
 </div>
 <div class="thanks outer-info">


### PR DESCRIPTION
#### What's this PR do?

Updates the link on the main page to member contribution form. Adds link to form at bottom of right column on the circle member page.
#### Why are we doing this? How does it help us?

Makes sure our forms are up-to-date. Also makes sure that our circle membership form is easy to find. I updated the links so that they are more general, and we should, in future, be able to just replace both forms on S3 and push no code to update them :tada:.
#### How should this be manually tested?

Run the site locally. 
- Visit the homepage. Click on the PDF link in the Mail a Check section at the bottom of the right column. Confirm it takes you to an updated form. 
- Visit the circle page. See that there is a Mail a Check section at the bottom of the right column. Confirm that it takes you to a circle member form.
#### Have automated tests been added?

no
#### Are there performance implications? If adding JS can it be done async? Do images/CSS/JS have cache headers set?

no
#### What are the relevant tickets?

https://3.basecamp.com/3098728/buckets/736178/todos/180227432
#### How should this change be communicated to end users?

Let Suzanne know these are updated/added.
#### Next steps?

When deploying, clear cache to make sure the updated forms show up in a timely manner.
#### Smells?

no
#### TODOs:
#### Has the relevant documentation/wiki been updated?
#### Technical debt note

same / slightly less, as hopefully won't deploy code for future updates
