### PR TITLE
add basic print styles for circle membership

### DIFF
--- a/source/_footer.erb
+++ b/source/_footer.erb
@@ -1,4 +1,4 @@
-<footer id="footer" class="footer">
+<footer id="footer" class="no_print footer">
   <nav class="left-nav">
     <ul>
       <li class="copyright">&copy; 2016 <a href="http://www.texastribune.org/">The Texas Tribune</a></li>

--- a/source/circle.html.erb
+++ b/source/circle.html.erb
@@ -74,6 +74,6 @@ title: Circle Membership
     </div>
   </div>
 </div>
-<div class="thanks outer-info">
+<div class="thanks outer-info no_print">
   <div class="inner-info"><hr>Thank you for supporting The Texas Tribune<hr></div>
 </div>

--- a/source/circle.html.erb
+++ b/source/circle.html.erb
@@ -2,7 +2,7 @@
 title: Circle Membership
 ---
 
-<div class="splash">
+<div class="splash no_print">
   <div class="splash-wrapper">
     <div class="splash-greeting">
       <h1 class="splash-header">Join Our Circle</h1>
@@ -17,8 +17,8 @@ title: Circle Membership
             <p><em>Three-Year Commitment</em></p>
           </div>
           <div class="circle-box-bottom">
-            <a href="https://checkout.texastribune.org/circleform?&amp;amount=<%= level.amount_annual %>&amp;installmentPeriod=yearly&amp;installments=3" onclick="ga('send', 'event', 'donations-app', 'click', 'circle-yearly', {'nonInteraction': 1})"><button class="button button-flat">$<%= level.amount_annual_comma %> <br>Annually</button></a>
-            <a href="https://checkout.texastribune.org/circleform?&amp;amount=<%= level.amount_month %>&amp;installmentPeriod=monthly&amp;installments=3" onclick="ga('send', 'event', 'donations-app', 'click', 'circle-monthly', {'nonInteraction': 1})"><button style="float: right;" class="button button-flat">$<%= level.amount_month %> <br>Monthly</button></a>
+            <a href="https://checkout.texastribune.org/circleform?&amp;amount=<%= level.amount_annual %>&amp;installmentPeriod=yearly&amp;installments=3" ga-on="click" ga-event-category="Donate" ga-event-action="checkout-intent" ga-event-label="circle-yearly"><button class="button button-flat">$<%= level.amount_annual_comma %> <br>Annually</button></a>
+            <a href="https://checkout.texastribune.org/circleform?&amp;amount=<%= level.amount_month %>&amp;installmentPeriod=monthly&amp;installments=3" ga-on="click" ga-event-category="Donate" ga-event-action="checkout-intent" ga-event-label="circle-monthly"><button style="float: right;" class="button button-flat">$<%= level.amount_month %> <br>Monthly</button></a>
           </div>
         </div>
       <% end %>
@@ -28,7 +28,7 @@ title: Circle Membership
 </div><!-- splash-circle -->
 
 <div class="main">
-  <div class="main-left">
+  <div class="main-left print_full">
   <div class="circle-members-header">
     <img class="circle-logo" src="../images/circle-member-half-logo.png">
   </div>
@@ -38,7 +38,7 @@ title: Circle Membership
     <div class="circle-list-wrapper" id="editor-s-circle"></div>
   </div>
   </div>
-  <div class="main-right level">
+  <div class="main-right level no_print">
     <h3 class="section-header">Circle Membership</h3>
     <p>Circle Membership is a three-year commitment to provide backing for the vital work of our journalists. Circle Members believe in supporting our mission as a public service — free of charge on our website, in free syndication and at our numerous free public events — so all Texans have access to nonpartisan news and information.</p>
     <h3 class="section-header">Benefits</h3>
@@ -70,7 +70,7 @@ title: Circle Membership
     <hr>
     <div class="extra-info">
       <h3>Prefer to mail a check?</h3>
-      <p>Click <a href="https://static.texastribune.org/media/marketing/TT-circle-membership-contribution-form.pdf" onclick="ga('send', 'event', 'donations-app', 'click', 'mail-check', {'nonInteraction': 1})">here</a> for our membership form and mailing information. </p>
+      <p>Click <a href="https://static.texastribune.org/media/marketing/TT-circle-membership-contribution-form.pdf" ga-on="click" ga-event-category="Donate" ga-event-action="checkout-intent" ga-event-label="mail-check">here</a> for our membership form and mailing information. </p>
     </div>
   </div>
 </div>

--- a/source/stylesheets/_circle.scss
+++ b/source/stylesheets/_circle.scss
@@ -90,6 +90,10 @@
   text-align: center;
   .circle-logo {
     max-width: 60%;
+
+    @media print {
+      max-width: 200px;
+    }
   }
 }
 
@@ -98,6 +102,10 @@
   .circle-list-wrapper {
     margin-bottom: 1em;
     text-align: center;
+
+    @media print {
+      margin: 0 1.8em 1em;
+    }
   }
 
   .circle-title {
@@ -106,11 +114,19 @@
     letter-spacing: 3px;
     padding: .5em;
     font-size: 1.5em;
+
+    @media print {
+      font-size: 1em;
+    }
   }
 
   .circle-list {
     font-size: 1em;
     line-height: 1.5em;
+
+    @media print {
+      font-size: .78em;
+    }
   }
 
   .yellow-star {

--- a/source/stylesheets/_circle.scss
+++ b/source/stylesheets/_circle.scss
@@ -15,6 +15,30 @@
   .tagline {
     margin: 1em 0 0.5em 0;
   }
+
+  @page {
+    size: 5.5in 8.5in;
+    margin: 70pt 60pt 70pt;
+  }
+
+
+  .no_print {
+    @media print {
+      display: none;
+    }
+  }
+  .print_full {
+    @media print {
+      @include span-columns(12);
+      @include media($tablet) {
+        @include span-columns(12);
+      }
+      @include media($mobile) {
+        @include span-columns(12);
+        padding: 0 1em;
+      }
+    }
+  }
 }
 
 .circle-box {

--- a/source/stylesheets/_circle.scss
+++ b/source/stylesheets/_circle.scss
@@ -17,8 +17,8 @@
   }
 
   @page {
-    size: 5.5in 8.5in;
-    margin: 70pt 60pt 70pt;
+    margin: 1cm;
+    size: A4;
   }
 
 

--- a/source/stylesheets/_layout.scss
+++ b/source/stylesheets/_layout.scss
@@ -8,6 +8,15 @@
       @include span-columns(8);
     }
   }
+
+  @media print {
+    margin: 24px auto 0;
+    text-align: center;
+
+    img {
+      width: 33%;
+    }
+  }
 }
 
 


### PR DESCRIPTION
#### What's this PR do?
Hides the header and sidebar, so that membership can print the Circle Membership list.

#### Why are we doing this? How does it help us?
The membership team has to create a document with the full list of members each month, and has a difficult time with copy/pasting the information in the way it is formatted on the website. This should make the process easier for them.

#### How should this be manually tested?
Run the donations app and print `/circle.html` — it should have "Circle Membership" and the TT logo at the top, followed by the various circle groups and all the names.

#### Have automated tests been added?
No

#### Are there performance implications? If adding JS can it be done async? Do images/CSS/JS have cache headers set?
n/a

#### What are the relevant tickets?
https://3.basecamp.com/3098728/buckets/736178/todos/321774759

#### How should this change be communicated to end users?
We should show Suzanne and membership a print preview to see if they need any additional changes.

#### Next steps?

#### Smells?
The page margins are a bit wacko. IDK.

#### TODOs:
* [ ] your TODO here

#### Has the relevant documentation/wiki been updated?

#### Technical debt note
