### PR TITLE
add google tag manager

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -30,6 +30,14 @@
     <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
     <%= javascript_include_tag  "all" %>
 
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-P5L2Z5Z');</script>
+    <!-- End Google Tag Manager -->
+
     <!-- Facebook Pixel Code -->
     <script>
     !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
@@ -46,6 +54,11 @@
     <!-- End Facebook Pixel Code -->
   </head>
   <body class="<%= page_classes %> no-js">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P5L2Z5Z"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    
     <%= partial "header" %>
 
     <%= yield %>


### PR DESCRIPTION
#### What's this PR do?
We're adding a Google Tag Manager to all pages of the site in order to implement LunaMetrics' analytics strategy. This adds it to all `support.texastribune.org` pages.

#### Why are we doing this? How does it help us?
Analytics tracking. It's a requirement of the strategy put forth by LunaMetrics.

#### How should this be manually tested?
View the page source on the following, and ensure that "Google Tag Manager" appears 4 times. There should be a `<script>` inside the `<head>` and a `<noscript><iframe>` right underneath the `<body>`.
+ index
+ `/levels`
+ `/circle`
+ `/faq`

#### Have automated tests been added?
no

#### Are there performance implications? If adding JS can it be done async? Do images/CSS/JS have cache headers set?
no

#### What are the relevant tickets?
https://3.basecamp.com/3098728/buckets/736178/todos/375513240

#### How should this change be communicated to end users?
Will discuss with audience & Luna at the check-in tomorrow afternoon.

#### Next steps?
n/a

#### Smells?
n/a

#### Has the relevant documentation/wiki been updated?
n/a

#### Technical debt note
n/a