### PR TITLE
Pass on campaign ID to checkout

### DIFF
--- a/raw/js/form.js
+++ b/raw/js/form.js
@@ -345,7 +345,7 @@ export default class FormHandler {
     let params = window.location.search;
 
     if (params) {
-      params = params.replace('?', '').split('&');
+      params = params.replace(/\?/g, '').split('&');
 
       params.forEach((param) => {
         const splitParam = param.split('=');

--- a/raw/js/form.js
+++ b/raw/js/form.js
@@ -381,7 +381,7 @@ export default class FormHandler {
     }
 
     if (campaignID) {
-      fullURL += `&campaignid=${campaignID}`;
+      fullURL += `&campaignId=${campaignID}`;
     }
 
     return fullURL;

--- a/raw/js/form.js
+++ b/raw/js/form.js
@@ -340,9 +340,29 @@ export default class FormHandler {
     return inputObject;
   }
 
+  getCampaignID() {
+    let campaignID = null;
+    let params = window.location.search;
+
+    if (params) {
+      params = params.replace('?', '').split('&');
+
+      params.forEach((param) => {
+        const splitParam = param.split('=');
+
+        if (splitParam[0].toLowerCase() === 'campaignid') {
+          campaignID = splitParam[1];
+        }
+      });
+    }
+
+    return campaignID;
+  }
+
   // the final step
   // sends users to the proper checkout screen
   getCheckoutURL(inputObject) {
+    const campaignID = this.getCampaignID();
     const amount = inputObject.amount;
     const frequency = inputObject.frequency;
     const baseURL = 'https://checkout.texastribune.org';
@@ -358,6 +378,10 @@ export default class FormHandler {
       case 'yearly':
         fullURL = `${baseURL}/memberform?installmentPeriod=yearly&amount=${amount}`;
         break;
+    }
+
+    if (campaignID) {
+      fullURL += `&campaignid=${campaignID}`;
     }
 
     return fullURL;


### PR DESCRIPTION
#### What's this PR do?
Checks whether a `campaignid` query parameter exists. If so, it's passed on to the checkout app also as a query parameter.

#### Why are we doing this? How does it help us?
It enables marketing to track the success of campaigns.

#### How should this be manually tested?
If you don't have the app set up, consult the README. If you do:
- `npm run dev`
- Open `http://localhost:4567/`
- Append `?campaignid=<any-number>` to the URL
- Move through the widget and click "go to checkout."
- Confirm the checkout page you land on has the same campaignid query parameter.
- Now let's try to break it. Go back to the support page and add another query parameter (i.e. `http://localhost:4567/?foo=bar&campaignid=1234`). Confirm you still get the proper query param on the checkout page.
- Try adding some errant ampersands (i.e. `http://localhost:4567/?&&foo=bar&&&campaignid=1234`). Confirm you still get the proper query param on the checkout page.
- Try changing up the order of the query parameters, with or without errant ampersands. Confirm you still get the proper query param on the checkout page.
- Try adding extra question marks (i.e. `http://localhost:4567/????campaignid=1234`). Confirm you still get the proper query param on the checkout page.

#### Have automated tests been added?
No.

#### Are there performance implications? If adding JS can it be done async? Do images/CSS/JS have cache headers set?
No.

#### What are the relevant tickets?
https://3.basecamp.com/3098728/buckets/736178/todos/638106903

#### How should this change be communicated to end users?
NA.

#### Next steps?
NA.

#### Smells?
NA.

#### TODOs:
* [x] Get actual name of query parameter that will be used (not sure it will actually be `campaignid`)

#### Has the relevant documentation/wiki been updated?
NA.

#### Technical debt note
Same.