### PR TITLE
Bust FB cache on deploy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,13 @@
 
 #### Why are we doing this? How does it help us?
 
+#### Have you done the following membership-specific things (if necessary)?
+* [ ] Update campaign ID
+* [ ] If launching a campaign, redirect `index.html` to `campaign.html` (probably)
+* [ ] If ending a campaign, redirect `campaign.html` to `index.html` (probably)
+* [ ] Update social meta tags
+* [ ] After deploy, [bust](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/guides/troubleshooting-cards) the Twitter card cache
+
 #### How should this be manually tested?
 
 #### Have automated tests been added?

--- a/README.md
+++ b/README.md
@@ -47,9 +47,16 @@ You'll typically only need these three: `yarn run dev`, `yarn run build` and `ya
 
 ## Deployment
 1. Build for production: `yarn run build`
-2. Push to S3: `yarn run deploy`
+2. Push to S3: `yarn run deploy` (this also automatically busts the FB OG cache)
 
 You can combine the build and deploy into one step with `yarn run build:deploy`.
+
+
+## Campaign IDs
+Membership uses unique IDs to track specific campaigns (FMD, Giving Tuesday, etc.). If a campaign is in progress, we hard-code that ID into the donation-widget form (see markup below). This is to ensure *every* click of "Go To Checkout" passes the ID onto our checkout app.
+`<input id="campaign-id" type="hidden" value="<campaign-id>" name="campaignId">`
+
+If a campaign is *not* in progress, that hidden field should not be present. However, we still want to pass campaign IDs to checkout *if* `campaignId` is included as a query parameter. (For campaigns, our membership folks create special URLs to support.texastribune.org that include that query parameter.) That's why [this code](https://github.com/texastribune/donations-app/blob/master/source/javascripts/form.js#L212-L216) exists. The thinking is we want to ensure remnant donations spurred by campaign marketing materials still get recorded as part of that campaign, even if the date of giving is after we've removed the hidden field.
 
 
 ## Browser support

--- a/env.sample
+++ b/env.sample
@@ -1,3 +1,4 @@
 AWS_ACCESS_KEY_ID=<your-key>
 AWS_SECRET_ACCESS_KEY=<your-secret-key>
 APP_S3_BUCKET=support.texastribune.org
+FB_ACCESS_TOKEN=<redacted>

--- a/utils/deploy.sh
+++ b/utils/deploy.sh
@@ -14,3 +14,12 @@ aws s3 sync --acl public-read --delete --include '*.jpg' --include '*.png' --inc
 
 echo "Syncing everything else to S3..."
 aws s3 sync build s3://$APP_S3_BUCKET/
+
+echo "Busting Facebook Open Graph cache..."
+for URL in 'index' 'levels' 'faq' 'circle' 'campaign'
+do
+  echo "Busting $URL.html..."
+  curl -d "id=https://support.texastribune.org/$URL.html&scrape=true&access_token=$FB_ACCESS_TOKEN" -X POST https://graph.facebook.com
+  printf "\n\n"
+  sleep 1
+done


### PR DESCRIPTION
#### What's this PR do?
+ Adds a step to our deployment shell script that hits a Facebook endpoint to bust the cache on OG meta tags.
+ Updates docs with info about campaign IDs
+ Adds a checklist to the PR template for membership-specific tasks

#### Why are we doing this? How does it help us?
I'm bad at remembering to manually use the FB debugger to update OG meta tags.

#### How should this be manually tested?
I tested this on one production page (`/circle.html`) already, and it seems to be working swell. So just do the following:
+ Add the TT Facebook OG access to token to `env-docker`. If you can't find it, let me know.
+ `make`
+ Open `/utils/deploy.sh` and remove [these lines](https://github.com/texastribune/donations-app/blob/fb-bust/utils/deploy.sh#L3-L16).
+ `yarn run deploy`. Terminal should list the page names as they're busted and spit out JSON that reflects the latest OG meta.

#### Have automated tests been added?
No.

#### Are there performance implications? If adding JS can it be done async? Do images/CSS/JS have cache headers set?
NA.

#### What are the relevant tickets?https://3.basecamp.com/3098728/buckets/736178/todos/794579361

#### How should this change be communicated to end users?
NA.

#### Next steps?
NA.

#### Smells?
I did some Googling, and it seems there isn't a great automated way to bust the Twitter meta cache. So I added an item in the PR-template membership checklist that's part of this PR to do that manually.

#### TODOs:
NA.

#### Has the relevant documentation/wiki been updated?
Yes.

#### Technical debt note
Same.