### PR TITLE
Six amount options --> three options

### DIFF
--- a/source/_checkout.erb
+++ b/source/_checkout.erb
@@ -29,18 +29,6 @@
           <input id="amount-2" class="checkout__amounts-radio visually-hidden" type="radio" value="15" name="amount" checked>
           <label for="amount-2" class="checkout__amounts-label">$15</label>
         </li>
-        <li class="checkout__amounts-item">
-          <input id="amount-3" class="checkout__amounts-radio visually-hidden" type="radio" value="25" name="amount">
-          <label for="amount-3" class="checkout__amounts-label">$25</label>
-        </li>
-        <li class="checkout__amounts-item">
-          <input id="amount-4" class="checkout__amounts-radio visually-hidden" type="radio" value="55" name="amount">
-          <label for="amount-4" class="checkout__amounts-label">$55</label>
-        </li>
-        <li class="checkout__amounts-item">
-          <input id="amount-5" class="checkout__amounts-radio visually-hidden" type="radio" value="85" name="amount">
-          <label for="amount-5" class="checkout__amounts-label">$85</label>
-        </li>
       </ul>
       <div class="checkout__manual clearfix">
         <div class="checkout__manual-inner">
@@ -54,7 +42,7 @@
     </formset>
 
     <formset class="checkout__group checkout__group--submit clearfix">
-      <input id="checkout-submit" class="checkout__submit" type="submit" value="" onclick="ga('send', 'event', 'Support Page', 'donations-app', 'go-to-checkout', {'nonInteraction': 1})">
+      <input id="checkout-submit" class="checkout__submit" type="submit" value="Give $15 monthly" onclick="ga('send', 'event', 'Support Page', 'donations-app', 'go-to-checkout', {'nonInteraction': 1})">
     </formset>
   </form>
 </div>

--- a/source/_checkout.erb
+++ b/source/_checkout.erb
@@ -22,11 +22,11 @@
           <label for="amount-0" class="checkout__amounts-label">$5</label>
         </li>
         <li class="checkout__amounts-item">
-          <input id="amount-1" class="checkout__amounts-radio visually-hidden" type="radio" value="10" name="amount">
+          <input id="amount-1" class="checkout__amounts-radio visually-hidden" type="radio" value="10" name="amount" checked>
           <label for="amount-1" class="checkout__amounts-label">$10</label>
         </li>
         <li class="checkout__amounts-item">
-          <input id="amount-2" class="checkout__amounts-radio visually-hidden" type="radio" value="15" name="amount" checked>
+          <input id="amount-2" class="checkout__amounts-radio visually-hidden" type="radio" value="15" name="amount">
           <label for="amount-2" class="checkout__amounts-label">$15</label>
         </li>
       </ul>
@@ -42,7 +42,7 @@
     </formset>
 
     <formset class="checkout__group checkout__group--submit clearfix">
-      <input id="checkout-submit" class="checkout__submit" type="submit" value="Give $15 monthly" onclick="ga('send', 'event', 'Support Page', 'donations-app', 'go-to-checkout', {'nonInteraction': 1})">
+      <input id="checkout-submit" class="checkout__submit" type="submit" value="Give $10 monthly" onclick="ga('send', 'event', 'Support Page', 'donations-app', 'go-to-checkout', {'nonInteraction': 1})">
     </formset>
   </form>
 </div>

--- a/source/_checkout.erb
+++ b/source/_checkout.erb
@@ -18,16 +18,16 @@
     <formset class="checkout__group checkout__group--amounts clearfix">
       <ul id="amounts-attach" class="checkout__amounts clearfix">
         <li class="checkout__amounts-item">
-          <input id="amount-0" class="checkout__amounts-radio visually-hidden" type="radio" value="5" name="amount">
-          <label for="amount-0" class="checkout__amounts-label">$5</label>
+          <input id="amount-0" class="checkout__amounts-radio visually-hidden" type="radio" value="10" name="amount">
+          <label for="amount-0" class="checkout__amounts-label">$10</label>
         </li>
         <li class="checkout__amounts-item">
-          <input id="amount-1" class="checkout__amounts-radio visually-hidden" type="radio" value="10" name="amount" checked>
-          <label for="amount-1" class="checkout__amounts-label">$10</label>
+          <input id="amount-1" class="checkout__amounts-radio visually-hidden" type="radio" value="15" name="amount" checked>
+          <label for="amount-1" class="checkout__amounts-label">$15</label>
         </li>
         <li class="checkout__amounts-item">
-          <input id="amount-2" class="checkout__amounts-radio visually-hidden" type="radio" value="15" name="amount">
-          <label for="amount-2" class="checkout__amounts-label">$15</label>
+          <input id="amount-2" class="checkout__amounts-radio visually-hidden" type="radio" value="25" name="amount">
+          <label for="amount-2" class="checkout__amounts-label">$25</label>
         </li>
       </ul>
       <div class="checkout__manual clearfix">
@@ -42,7 +42,7 @@
     </formset>
 
     <formset class="checkout__group checkout__group--submit clearfix">
-      <input id="checkout-submit" class="checkout__submit" type="submit" value="Give $10 monthly" onclick="ga('send', 'event', 'Support Page', 'donations-app', 'go-to-checkout', {'nonInteraction': 1})">
+      <input id="checkout-submit" class="checkout__submit" type="submit" value="Give $15 monthly" onclick="ga('send', 'event', 'Support Page', 'donations-app', 'go-to-checkout', {'nonInteraction': 1})">
     </formset>
   </form>
 </div>

--- a/source/javascripts/form.js
+++ b/source/javascripts/form.js
@@ -2,8 +2,8 @@ export default class FormHandler {
   constructor() {
     this.monthlyAmounts = [5, 10, 15];
     this.yearlyAmounts = [50, 75, 100];
-    this.defaultMonthlyAmountsIndex = 2;
-    this.defaultYearlyAmountsIndex = 2;
+    this.defaultMonthlyAmountsIndex = 1;
+    this.defaultYearlyAmountsIndex = 1;
     this.amountsAttach = $('#amounts-attach');
     this.frequenciesRadiosClass = '.checkout__frequencies-radio';
     this.frequenciesRadios = $('.checkout__frequencies-radio');

--- a/source/javascripts/form.js
+++ b/source/javascripts/form.js
@@ -1,7 +1,7 @@
 export default class FormHandler {
   constructor() {
-    this.monthlyAmounts = [5, 10, 15, 25, 55, 85];
-    this.yearlyAmounts = [50, 75, 100, 250, 500, 1000];
+    this.monthlyAmounts = [5, 10, 15];
+    this.yearlyAmounts = [50, 75, 100];
     this.defaultMonthlyAmountsIndex = 2;
     this.defaultYearlyAmountsIndex = 2;
     this.amountsAttach = $('#amounts-attach');
@@ -112,11 +112,6 @@ export default class FormHandler {
     this._setSubmitText(currFrequency);
   }
 
-  _manualIsSelected() {
-    const selectedAmountEl = $(`${this.amountsRadiosClass}:checked`);
-    return selectedAmountEl.attr('id') === this.manualRadioId;
-  }
-
   _updateManualInputBorder(valid) {
     let borderClass;
 
@@ -220,26 +215,10 @@ export default class FormHandler {
     });
   }
 
-  _resetForm() {
-    this.form[0].reset();
-    this._clearManualInput();
-    this.frequenciesRadios.prop('checked', false);
-    this.amountsRadios.prop('checked', false);
-    this.resetFrequencyEl.prop('checked', true).change();
-    this.resetAmountEl.prop('checked', true).change();
-  }
-
   init() {
     this._bindAmountsEvents();
     this._bindFrequenciesEvents();
     this._bindManualEvents();
     this._bindSubmitEvents();
-    this._resetForm();
-
-    if (this._manualIsSelected()) {
-      this._setSubmitTextWithoutAmount();
-    } else {
-      this._setSubmitTextWithAmount();
-    }
   }
 }

--- a/source/javascripts/form.js
+++ b/source/javascripts/form.js
@@ -1,7 +1,7 @@
 export default class FormHandler {
   constructor() {
-    this.monthlyAmounts = [5, 10, 15];
-    this.yearlyAmounts = [50, 75, 100];
+    this.monthlyAmounts = [10, 15, 25];
+    this.yearlyAmounts = [75, 150, 500];
     this.defaultMonthlyAmountsIndex = 1;
     this.defaultYearlyAmountsIndex = 1;
     this.amountsAttach = $('#amounts-attach');


### PR DESCRIPTION
#### What's this PR do?
Reduces the number of preset amount choices from six to three.

#### Why are we doing this? How does it help us?
Request from Rebecca and Amanda in hopes it will simplify the user experience.

#### How should this be manually tested?
+ `make`
+ `yarn run dev`
+ Go to `http://localhost:4567` and confirm there are three options and that they update when you click "yearly"

#### Have automated tests been added?
No.

#### Are there performance implications? If adding JS can it be done async? Do images/CSS/JS have cache headers set?
No.

#### What are the relevant tickets?
https://3.basecamp.com/3098728/buckets/736178/todos/810232009

#### How should this change be communicated to end users?
They'll love it.

#### Next steps?
Measure!

#### Smells?
NA.

#### TODOs:
NA.

#### Has the relevant documentation/wiki been updated?
NA.

#### Technical debt note
Same.